### PR TITLE
Add rate limit for manhuagui website

### DIFF
--- a/helpers/checkers/base.py
+++ b/helpers/checkers/base.py
@@ -96,7 +96,7 @@ class AbstractChapterChecker(ABC):
 
         return response
 
-    def get_lastest_post_response(
+    def get_latest_post_response(
         self,
         url: str = None,
         data: dict = None,

--- a/helpers/checkers/manhuagui.py
+++ b/helpers/checkers/manhuagui.py
@@ -55,12 +55,12 @@ class ManhuaguiChecker(AbstractChapterChecker):
         self._wait_for_rate_limit()
         return super().get_latest_response(url, apparent_encoding)
 
-    def get_lastest_post_response(
+    def get_latest_post_response(
         self, url: str = None, data: dict = None, apparent_encoding: bool = True
     ):
         """Override to add rate limiting before making POST requests"""
         self._wait_for_rate_limit()
-        return super().get_lastest_post_response(url, data, apparent_encoding)
+        return super().get_latest_post_response(url, data, apparent_encoding)
 
     @classmethod
     def set_rate_limit_interval(cls, interval_seconds: int) -> None:

--- a/helpers/checkers/manhuagui.py
+++ b/helpers/checkers/manhuagui.py
@@ -1,3 +1,5 @@
+import threading
+import time
 from typing import List
 from urllib.parse import urlparse, urlunparse
 
@@ -5,12 +7,77 @@ from bs4.element import Tag
 
 from helpers.chapter import Chapter
 from helpers.checkers.base import AbstractChapterChecker
+from helpers.utils import get_logger
 
 
 class ManhuaguiChecker(AbstractChapterChecker):
     """Manhuagui chapter list"""
 
     URL_SUBSTRING = "manhuagui"
+
+    # Class-level rate limiting variables
+    _last_request_time = 0
+    _min_request_interval = 30  # 30 seconds minimum between requests
+    _request_lock = None
+    _logger = get_logger(__name__)
+
+    def __init__(self, check_url: str) -> None:
+        """Initialize ManhuaguiChecker with rate limiting"""
+        super().__init__(check_url)
+        # Import threading here to avoid circular imports
+        if ManhuaguiChecker._request_lock is None:
+            ManhuaguiChecker._request_lock = threading.Lock()
+
+        # Set more conservative request parameters for manhuagui
+        self.retry_interval = 10  # Increase retry interval to 10 seconds
+        self.max_retry_num = 2  # Reduce max retries to avoid too many attempts
+
+    def _wait_for_rate_limit(self) -> None:
+        """Enforce rate limiting by waiting if necessary"""
+        with ManhuaguiChecker._request_lock:
+            current_time = time.time()
+            time_since_last_request = current_time - ManhuaguiChecker._last_request_time
+
+            if time_since_last_request < ManhuaguiChecker._min_request_interval:
+                wait_time = (
+                    ManhuaguiChecker._min_request_interval - time_since_last_request
+                )
+                ManhuaguiChecker._logger.info(
+                    "Rate limiting for manhuagui: waiting %.1f seconds before next request",
+                    wait_time,
+                )
+                time.sleep(wait_time)
+
+            ManhuaguiChecker._last_request_time = time.time()
+
+    def get_latest_response(self, url: str = None, apparent_encoding: bool = True):
+        """Override to add rate limiting before making requests"""
+        self._wait_for_rate_limit()
+        return super().get_latest_response(url, apparent_encoding)
+
+    def get_lastest_post_response(
+        self, url: str = None, data: dict = None, apparent_encoding: bool = True
+    ):
+        """Override to add rate limiting before making POST requests"""
+        self._wait_for_rate_limit()
+        return super().get_lastest_post_response(url, data, apparent_encoding)
+
+    @classmethod
+    def set_rate_limit_interval(cls, interval_seconds: int) -> None:
+        """Set the minimum interval between requests
+
+        Args:
+            interval_seconds (int): Minimum seconds between requests
+        """
+        if interval_seconds > 0:
+            cls._min_request_interval = interval_seconds
+            cls._logger.info(
+                "Manhuagui rate limit interval set to %d seconds", interval_seconds
+            )
+        else:
+            cls._logger.warning(
+                "Invalid rate limit interval: %d. Must be positive.", interval_seconds
+            )
 
     def get_latest_chapter_list(self) -> List[Chapter]:
         """Get latest chapter list from manhuagui

--- a/helpers/checkers/qiman.py
+++ b/helpers/checkers/qiman.py
@@ -29,7 +29,7 @@ class QimanChecker(AbstractChapterChecker):
 
         try:
             # Send with POST method
-            response = self.get_lastest_post_response(
+            response = self.get_latest_post_response(
                 url=api_url, data={"id": comic_id, "id2": 1}
             )
             """Sample response:

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -165,5 +165,5 @@ class TestCheckers(unittest.TestCase):
         """Laimanhua"""
         self.universal_checking(
             test_checker=checkers.LaimanhuaChecker,
-            check_url="https://www.laimanhua8.com/kanmanhua/quanzhiduzheshijiao/",
+            check_url="https://www.laimanhua88.com/kanmanhua/quanzhiduzheshijiao/",
         )

--- a/tests/test_manhuagui_rate_limiting.py
+++ b/tests/test_manhuagui_rate_limiting.py
@@ -208,12 +208,14 @@ class TestManhuaguiRateLimiting(unittest.TestCase):
         # First call
         checker._wait_for_rate_limit()
 
-        # Simulate waiting longer than the rate limit interval
-        with patch("time.time", side_effect=[0, 1.1, 1.1, 1.2]):
-            # Second call should not be delayed
-            start_time = time.time()
-            checker._wait_for_rate_limit()
-            duration = time.time() - start_time
+        # Wait longer than the rate limit interval
+        time.sleep(1.1)
+
+        # Second call should not be delayed
+        start_time = time.time()
+        checker._wait_for_rate_limit()
+        duration = time.time() - start_time
+
         # Should be fast since enough time has passed
         self.assertLess(duration, 0.1)
 

--- a/tests/test_manhuagui_rate_limiting.py
+++ b/tests/test_manhuagui_rate_limiting.py
@@ -31,7 +31,9 @@ class TestManhuaguiRateLimiting(unittest.TestCase):
 
         # Check that lock is created
         self.assertIsNotNone(ManhuaguiChecker._request_lock)
-        self.assertIsInstance(ManhuaguiChecker._request_lock, threading.Lock)
+        # Check that the lock has the expected lock methods (duck typing approach)
+        self.assertTrue(hasattr(ManhuaguiChecker._request_lock, "acquire"))
+        self.assertTrue(hasattr(ManhuaguiChecker._request_lock, "release"))
 
         # Check default values
         self.assertEqual(ManhuaguiChecker._min_request_interval, 30)

--- a/tests/test_manhuagui_rate_limiting.py
+++ b/tests/test_manhuagui_rate_limiting.py
@@ -1,0 +1,224 @@
+"""Unit tests for ManhuaguiChecker rate limiting functionality."""
+
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from helpers.checkers.manhuagui import ManhuaguiChecker
+
+
+class TestManhuaguiRateLimiting(unittest.TestCase):
+    """Test rate limiting functionality of ManhuaguiChecker"""
+
+    def setUp(self):
+        """Set up test environment"""
+        # Reset class variables before each test
+        ManhuaguiChecker._last_request_time = 0
+        ManhuaguiChecker._min_request_interval = 30
+        ManhuaguiChecker._request_lock = None
+
+    def tearDown(self):
+        """Clean up after each test"""
+        # Reset class variables after each test
+        ManhuaguiChecker._last_request_time = 0
+        ManhuaguiChecker._min_request_interval = 30
+        ManhuaguiChecker._request_lock = None
+
+    def test_rate_limit_initialization(self):
+        """Test that rate limiting variables are properly initialized"""
+        checker = ManhuaguiChecker("https://m.manhuagui.com/comic/17165/")
+
+        # Check that lock is created
+        self.assertIsNotNone(ManhuaguiChecker._request_lock)
+        self.assertIsInstance(ManhuaguiChecker._request_lock, threading.Lock)
+
+        # Check default values
+        self.assertEqual(ManhuaguiChecker._min_request_interval, 30)
+        self.assertEqual(checker.retry_interval, 10)
+        self.assertEqual(checker.max_retry_num, 2)
+
+    def test_set_rate_limit_interval_valid(self):
+        """Test setting valid rate limit interval"""
+        ManhuaguiChecker.set_rate_limit_interval(60)
+        self.assertEqual(ManhuaguiChecker._min_request_interval, 60)
+
+        ManhuaguiChecker.set_rate_limit_interval(15)
+        self.assertEqual(ManhuaguiChecker._min_request_interval, 15)
+
+    def test_set_rate_limit_interval_invalid(self):
+        """Test setting invalid rate limit interval"""
+        original_interval = ManhuaguiChecker._min_request_interval
+
+        # Test negative value
+        ManhuaguiChecker.set_rate_limit_interval(-5)
+        self.assertEqual(ManhuaguiChecker._min_request_interval, original_interval)
+
+        # Test zero value
+        ManhuaguiChecker.set_rate_limit_interval(0)
+        self.assertEqual(ManhuaguiChecker._min_request_interval, original_interval)
+
+    def test_rate_limiting_timing(self):
+        """Test that rate limiting enforces correct timing"""
+        # Set a short interval for testing
+        ManhuaguiChecker.set_rate_limit_interval(2)
+
+        checker = ManhuaguiChecker("https://m.manhuagui.com/comic/17165/")
+
+        # First call should go through immediately
+        start_time = time.time()
+        checker._wait_for_rate_limit()
+        first_call_time = time.time() - start_time
+
+        # Should be very fast (less than 0.1 seconds)
+        self.assertLess(first_call_time, 0.1)
+
+        # Second call should be delayed
+        start_time = time.time()
+        checker._wait_for_rate_limit()
+        second_call_time = time.time() - start_time
+
+        # Should wait at least the rate limit interval (allowing small margin)
+        self.assertGreaterEqual(second_call_time, 1.9)
+
+    def test_rate_limiting_thread_safety(self):
+        """Test that rate limiting works correctly with multiple threads"""
+        ManhuaguiChecker.set_rate_limit_interval(1)  # 1 second for testing
+
+        results = []
+        start_time = time.time()
+
+        def worker():
+            checker = ManhuaguiChecker("https://m.manhuagui.com/comic/17165/")
+            checker._wait_for_rate_limit()
+            results.append(time.time() - start_time)
+
+        # Create multiple threads
+        threads = []
+        for _ in range(3):
+            thread = threading.Thread(target=worker)
+            threads.append(thread)
+
+        # Start all threads
+        for thread in threads:
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # Sort results to check timing
+        results.sort()
+
+        # Should have 3 results
+        self.assertEqual(len(results), 3)
+
+        # Each request should be at least 1 second apart (allowing small margin)
+        if len(results) >= 2:
+            self.assertGreaterEqual(results[1] - results[0], 0.9)
+        if len(results) >= 3:
+            self.assertGreaterEqual(results[2] - results[1], 0.9)
+
+    @patch("helpers.checkers.base.AbstractChapterChecker.get_latest_response")
+    def test_get_latest_response_rate_limited(self, mock_super_response):
+        """Test that get_latest_response applies rate limiting"""
+        mock_response = MagicMock()
+        mock_super_response.return_value = mock_response
+
+        ManhuaguiChecker.set_rate_limit_interval(1)
+        checker = ManhuaguiChecker("https://m.manhuagui.com/comic/17165/")
+
+        # First call
+        start_time = time.time()
+        result1 = checker.get_latest_response()
+        first_duration = time.time() - start_time
+
+        # Second call should be rate limited
+        start_time = time.time()
+        result2 = checker.get_latest_response()
+        second_duration = time.time() - start_time
+
+        # Verify that the super method was called
+        self.assertEqual(mock_super_response.call_count, 2)
+
+        # Verify rate limiting was applied
+        self.assertLess(first_duration, 0.1)  # First call should be fast
+        self.assertGreaterEqual(second_duration, 0.9)  # Second call should wait
+
+        # Verify return values
+        self.assertEqual(result1, mock_response)
+        self.assertEqual(result2, mock_response)
+
+    @patch("helpers.checkers.base.AbstractChapterChecker.get_lastest_post_response")
+    def test_get_post_response_rate_limited(self, mock_super_post):
+        """Test that get_lastest_post_response applies rate limiting"""
+        mock_response = MagicMock()
+        mock_super_post.return_value = mock_response
+
+        ManhuaguiChecker.set_rate_limit_interval(1)
+        checker = ManhuaguiChecker("https://m.manhuagui.com/comic/17165/")
+
+        # First call
+        start_time = time.time()
+        result1 = checker.get_lastest_post_response()
+        first_duration = time.time() - start_time
+
+        # Second call should be rate limited
+        start_time = time.time()
+        result2 = checker.get_lastest_post_response()
+        second_duration = time.time() - start_time
+
+        # Verify that the super method was called
+        self.assertEqual(mock_super_post.call_count, 2)
+
+        # Verify rate limiting was applied
+        self.assertLess(first_duration, 0.1)  # First call should be fast
+        self.assertGreaterEqual(second_duration, 0.9)  # Second call should wait
+
+        # Verify return values
+        self.assertEqual(result1, mock_response)
+        self.assertEqual(result2, mock_response)
+
+    def test_multiple_instances_share_rate_limit(self):
+        """Test that multiple instances of ManhuaguiChecker share the same rate limit"""
+        ManhuaguiChecker.set_rate_limit_interval(1)
+
+        checker1 = ManhuaguiChecker("https://m.manhuagui.com/comic/17165/")
+        checker2 = ManhuaguiChecker("https://m.manhuagui.com/comic/12345/")
+
+        # First call from checker1
+        start_time = time.time()
+        checker1._wait_for_rate_limit()
+        first_duration = time.time() - start_time
+
+        # Second call from checker2 should still be rate limited
+        start_time = time.time()
+        checker2._wait_for_rate_limit()
+        second_duration = time.time() - start_time
+
+        # Verify rate limiting is shared
+        self.assertLess(first_duration, 0.1)  # First call should be fast
+        self.assertGreaterEqual(second_duration, 0.9)  # Second call should wait
+
+    def test_rate_limit_after_sufficient_time(self):
+        """Test that requests are not delayed if sufficient time has passed"""
+        ManhuaguiChecker.set_rate_limit_interval(1)
+        checker = ManhuaguiChecker("https://m.manhuagui.com/comic/17165/")
+
+        # First call
+        checker._wait_for_rate_limit()
+
+        # Wait longer than the rate limit interval
+        time.sleep(1.1)
+
+        # Second call should not be delayed
+        start_time = time.time()
+        checker._wait_for_rate_limit()
+        duration = time.time() - start_time
+
+        # Should be fast since enough time has passed
+        self.assertLess(duration, 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manhuagui_rate_limiting.py
+++ b/tests/test_manhuagui_rate_limiting.py
@@ -149,9 +149,9 @@ class TestManhuaguiRateLimiting(unittest.TestCase):
         self.assertEqual(result1, mock_response)
         self.assertEqual(result2, mock_response)
 
-    @patch("helpers.checkers.base.AbstractChapterChecker.get_lastest_post_response")
+    @patch("helpers.checkers.base.AbstractChapterChecker.get_latest_post_response")
     def test_get_post_response_rate_limited(self, mock_super_post):
-        """Test that get_lastest_post_response applies rate limiting"""
+        """Test that get_latest_post_response applies rate limiting"""
         mock_response = MagicMock()
         mock_super_post.return_value = mock_response
 
@@ -160,12 +160,12 @@ class TestManhuaguiRateLimiting(unittest.TestCase):
 
         # First call
         start_time = time.time()
-        result1 = checker.get_lastest_post_response()
+        result1 = checker.get_latest_post_response()
         first_duration = time.time() - start_time
 
         # Second call should be rate limited
         start_time = time.time()
-        result2 = checker.get_lastest_post_response()
+        result2 = checker.get_latest_post_response()
         second_duration = time.time() - start_time
 
         # Verify that the super method was called

--- a/tests/test_manhuagui_rate_limiting.py
+++ b/tests/test_manhuagui_rate_limiting.py
@@ -208,14 +208,12 @@ class TestManhuaguiRateLimiting(unittest.TestCase):
         # First call
         checker._wait_for_rate_limit()
 
-        # Wait longer than the rate limit interval
-        time.sleep(1.1)
-
-        # Second call should not be delayed
-        start_time = time.time()
-        checker._wait_for_rate_limit()
-        duration = time.time() - start_time
-
+        # Simulate waiting longer than the rate limit interval
+        with patch("time.time", side_effect=[0, 1.1, 1.1, 1.2]):
+            # Second call should not be delayed
+            start_time = time.time()
+            checker._wait_for_rate_limit()
+            duration = time.time() - start_time
         # Should be fast since enough time has passed
         self.assertLess(duration, 0.1)
 


### PR DESCRIPTION
This pull request introduces rate limiting to the `ManhuaguiChecker` class to comply with external API constraints and includes fixes for a typo in method names across multiple files. It also adds comprehensive unit tests to validate the rate limiting implementation.

### Rate Limiting for `ManhuaguiChecker`:

* Introduced class-level rate limiting variables (`_last_request_time`, `_min_request_interval`, `_request_lock`) and a `_wait_for_rate_limit` method to enforce a minimum interval between requests. (`helpers/checkers/manhuagui.py`, [helpers/checkers/manhuagui.pyR1-R81](diffhunk://#diff-fa03a668df4e0f32a3100f48c517b1e785d0a0b9df20f828e5a15468814e4e2cR1-R81))
* Overrode `get_latest_response` and `get_latest_post_response` methods to include rate limiting before making requests. (`helpers/checkers/manhuagui.py`, [helpers/checkers/manhuagui.pyR1-R81](diffhunk://#diff-fa03a668df4e0f32a3100f48c517b1e785d0a0b9df20f828e5a15468814e4e2cR1-R81))
* Added a `set_rate_limit_interval` method to allow dynamic configuration of the rate limit interval. (`helpers/checkers/manhuagui.py`, [helpers/checkers/manhuagui.pyR1-R81](diffhunk://#diff-fa03a668df4e0f32a3100f48c517b1e785d0a0b9df20f828e5a15468814e4e2cR1-R81))

### Typo Fixes:

* Fixed a typo in the method name `get_lastest_post_response` by renaming it to `get_latest_post_response` in `helpers/checkers/base.py` and `helpers/checkers/qiman.py`. [[1]](diffhunk://#diff-9f3fd8302fe9650b76ae6cdfbd1ac8627f9b9a3bd2d49538829dc75db436bb67L99-R99) [[2]](diffhunk://#diff-c1ff62c6cf730287b02c466dee2d979cf4caed4b6d377e55ee86288b2851c803L32-R32)

### Unit Tests:

* Added a new test suite `tests/test_manhuagui_rate_limiting.py` to validate rate limiting functionality, including timing enforcement, thread safety, and shared rate limiting across instances.